### PR TITLE
Include size of corpus in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,7 @@ randomWord();
 //=> 'microfloppies'
 ```
 
+The [underlying corpus](https://raw.githubusercontent.com/sindresorhus/word-list/master/words.txt) contains 274,925 English words.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,8 @@ randomWord();
 //=> 'microfloppies'
 ```
 
-The [underlying list of words](https://raw.githubusercontent.com/sindresorhus/word-list/master/words.txt) is a 2.68MB file with 274,925 English words.
+The [underlying list of words](words.txt) is a 2.7 MB text file with 274,925 English words.
+
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ randomWord();
 //=> 'microfloppies'
 ```
 
-The [underlying corpus](https://raw.githubusercontent.com/sindresorhus/word-list/master/words.txt) contains 274,925 English words.
+The [underlying list of words](https://raw.githubusercontent.com/sindresorhus/word-list/master/words.txt) is a 2.68MB file with 274,925 English words.
 
 ## Related
 


### PR DESCRIPTION
It would be helpful to include more info about the random word corpus in the readme. I was interested to learn how large the word-list was.

Following the dependencies, I see this is the corpus: https://raw.githubusercontent.com/sindresorhus/word-list/master/words.txt. Which GitHub [reports as a 2.68MB file](https://github.com/sindresorhus/word-list/blob/master/words.txt). But it's still not easily obvious how long the list is.

Downloading...
```
wc -l ~/Downloads/words.txt
  274925 ~/Downloads/words.txt
```

It would be great to include that `274,925` number in the documentation.

----

Thanks for putting this together.